### PR TITLE
Feature: Swift 5.10 • SwiftSyntax

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-13
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v3
     
     - name: Xcode 15
-      run: sudo xcode-select -s '/Applications/Xcode_15.2.app/Contents/Developer'
+      run: sudo xcode-select -s '/Applications/Xcode_15.3.app/Contents/Developer'
 
     - name: Build
       run: swift build

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "43c802fb7f96e090dde015344a94b5e85779eff1",
-        "version" : "509.1.0"
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     .library(name: "ReactBridge", targets: ["ReactBridge"])
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.1.0")
+    .package(url: "https://github.com/apple/swift-syntax.git", "509.0.0"..<"511.0.0")
   ],
   targets: [
     .macro(

--- a/Sources/ReactBridgeMacros/ObjcType.swift
+++ b/Sources/ReactBridgeMacros/ObjcType.swift
@@ -64,7 +64,9 @@ fileprivate let blockMap: [String : [String]] = [
   "RCTResponseErrorBlock": [],
   "RCTPromiseResolveBlock": [],
   "RCTPromiseRejectBlock": [],
+  "RCTDirectEventBlock": [],
   "RCTBubblingEventBlock": [],
+  "RCTCapturingEventBlock": [],
 ]
 
 fileprivate func objcType(swiftType: String, map: [String : [String]]) -> String? {

--- a/Tests/ReactBridgeTests/ReactBridgeTests.swift
+++ b/Tests/ReactBridgeTests/ReactBridgeTests.swift
@@ -564,8 +564,14 @@ final class ReactPropertyTests: XCTestCase {
         var set: Set<String>?
       
         @ReactProperty
+        var onBoundsChange: RCTDirectEventBlock?
+
+        @ReactProperty
         var onData: RCTBubblingEventBlock?
-      
+
+        @ReactProperty
+        var onSelection: RCTCapturingEventBlock?
+
         @ReactProperty(keyPath: "muted")
         var isMute: Bool?
       }
@@ -600,9 +606,15 @@ final class ReactPropertyTests: XCTestCase {
         var set: Set<String>?
       
         \(propConfig(name: "set", objcType: "NSSet"))
+        var onBoundsChange: RCTDirectEventBlock?
+
+        \(propConfig(name: "onBoundsChange", objcType: "RCTDirectEventBlock"))
         var onData: RCTBubblingEventBlock?
       
         \(propConfig(name: "onData", objcType: "RCTBubblingEventBlock"))
+        var onSelection: RCTCapturingEventBlock?
+
+        \(propConfig(name: "onSelection", objcType: "RCTCapturingEventBlock"))
         var isMute: Bool?
       
         \(propConfig(name: "isMute", objcType: "BOOL", keyPath: "muted"))

--- a/Tests/ReactBridgeTests/ReactMockTests.swift
+++ b/Tests/ReactBridgeTests/ReactMockTests.swift
@@ -1,6 +1,8 @@
 import Foundation
 
+typealias RCTDirectEventBlock = ([String : Any]) -> Void
 typealias RCTBubblingEventBlock = ([String : Any]) -> Void
+typealias RCTCapturingEventBlock = ([String : Any]) -> Void
 typealias RCTPromiseResolveBlock = (Any) -> Void
 typealias RCTPromiseRejectBlock = (String, String, NSError) -> Void
 


### PR DESCRIPTION
Note that one of the tests now fails, the error reads to me like removed functionality for Swift macros?

`ReactPropertyTests.test_multiple()`
> failed - message does not match - Actual output (+) differed from expected output (-):
–ReactBridge: @ReactProperty can only be applied to a single var
+peer macro can only be applied to a single variable

You should be able to push to my branch too to make modifications 🙏🏻 