### PR TITLE
fix: compilation of package using Swift 6 with Xcode 16b1

### DIFF
--- a/Sources/ReactBridgeMacros/ReactMethod.swift
+++ b/Sources/ReactBridgeMacros/ReactMethod.swift
@@ -39,7 +39,7 @@ struct ReactMethod {
 
 extension ReactMethod: PeerMacro {
   
-  private static var nonisolatedUnsafe: String = {
+  private static let nonisolatedUnsafe: String = {
 #if swift(>=5.10)
     "nonisolated(unsafe) "
 #else

--- a/Tests/ReactBridgeTests/ReactBridgeTests.swift
+++ b/Tests/ReactBridgeTests/ReactBridgeTests.swift
@@ -15,7 +15,7 @@ final class ReactMethodTests: XCTestCase {
     "ReactMethod": ReactMethod.self,
   ]
   
-  private static var nonisolatedUnsafe: String = {
+  private static let nonisolatedUnsafe: String = {
 #if swift(>=5.10)
     "nonisolated (unsafe) "
 #else


### PR DESCRIPTION
Fixes compilation of the package itself within Xcode 16b1, should have no impact on functionality.

Error fixed:
> Static property 'nonisolatedUnsafe' is not concurrency-safe because it is non-isolated global shared mutable state