### PR TITLE
fix: update `swift-syntax` GitHub URL from `apple` to `swiftlang` organisation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     .library(name: "ReactBridge", targets: ["ReactBridge"])
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.2")
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.2")
   ],
   targets: [
     .macro(


### PR DESCRIPTION
The old organisation causes SPM errors because other packages I use have updated the URL already.